### PR TITLE
Windows FireFox Support

### DIFF
--- a/src/firefox.rs
+++ b/src/firefox.rs
@@ -50,7 +50,7 @@ fn get_master_profile_path() -> PathBuf {
     } else if cfg!(target_os = "linux") {
         path.push(".mozilla/firefox/profiles.ini")
     } else if cfg!(target_os = "windows") {
-        path.push("AppData/Roaming/Mozilla/Firefox/profiles.ini")
+        path.push(r"AppData\Roaming\Mozilla\Firefox\profiles.ini")
     }
     path
 }

--- a/src/firefox.rs
+++ b/src/firefox.rs
@@ -49,6 +49,8 @@ fn get_master_profile_path() -> PathBuf {
         path.push("Library/Application Support/Firefox/profiles.ini");
     } else if cfg!(target_os = "linux") {
         path.push(".mozilla/firefox/profiles.ini")
+    } else if cfg!(target_os = "windows") {
+        path.push("AppData/Roaming/Mozilla/Firefox/profiles.ini")
     }
     path
 }


### PR DESCRIPTION
I was interested in experimenting with this library, but noticed it didn't support Windows, so I added support! After adding the path I was able to run the browsercookie binary and it seems to work fine.

Before opening this PR I noticed there was #10 from last month but it seemed to be closed immediately by the author. There seemed to be a couple of unrelated (?) changes in there so maybe that was why? Either way, happy to defer to that PR if it gets reopened, ultimately we're just adding the path to profiles.ini.

Thanks for the project!